### PR TITLE
Move the server count onto the icon, and follow it faster

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -75,7 +75,9 @@ Panel {
   property int blockedCount: 0
   property int doneCount: 0
   property int workingCount: 0
-  // The three states worth a badge. Anything else is the herd at rest.
+  // The three states that turn into each other without you touching anything.
+  // They decide the badge's colour, and they decide how often it is worth
+  // asking - an idle herd cannot change until you change it.
   readonly property bool badgeActive:
     blockedCount > 0 || doneCount > 0 || workingCount > 0
   property bool reachable: true
@@ -665,9 +667,11 @@ Panel {
   // Polled rather than subscribed: herdr has an event socket, but one per
   // server, and the count in the bar is the sort of thing that can be a few
   // seconds old. Faster while the panel is open, because the agent states in
-  // it are what you came to read.
+  // it are what you came to read, and faster while anything is live, because
+  // that is the only time the badge colour can go stale on its own. Idle costs
+  // one poll every twenty seconds and catches the moment you start something.
   Timer {
-    interval: root.opened ? 3000 : 20000
+    interval: root.opened ? 3000 : (root.badgeActive ? 5000 : 20000)
     running: true
     repeat: true
     triggeredOnStart: true

--- a/Panel.qml
+++ b/Panel.qml
@@ -63,6 +63,10 @@ Panel {
   // like a working one - which is the distinction this widget exists to draw.
   // So this one colour is picked rather than themed.
   readonly property color finished: "#5FA46B"
+  // Working is amber for the same reason, and because it used to borrow the
+  // accent: on a theme whose accent is red or green, "busy" was indistinguish-
+  // able from "needs you" or "finished" - the two the badge exists to separate.
+  readonly property color working: "#D6A84B"
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   property var sessions: []
@@ -71,6 +75,9 @@ Panel {
   property int blockedCount: 0
   property int doneCount: 0
   property int workingCount: 0
+  // The three states worth a badge. Anything else is the herd at rest.
+  readonly property bool badgeActive:
+    blockedCount > 0 || doneCount > 0 || workingCount > 0
   property bool reachable: true
   property string errorText: ""
   // Session the script is currently acting on, so its row can dim.
@@ -116,15 +123,7 @@ Panel {
   property int column: 0
   property int cursor: -1
 
-  readonly property int badgeCount: runningCount
-
-  // Width of the badge and of the whole icon+badge row. Computed here rather
-  // than read off the Row, because iconComponent is a Component with its own
-  // scope: ids inside it are not visible out here.
-  readonly property int badgeWidth: badgeCount > 0
-    ? Math.max(Style.space(12), String(badgeCount).length * Style.space(6) + Style.space(8))
-    : 0
-  readonly property int barContentWidth: Style.bar.iconFont + badgeWidth + Style.space(5)
+  readonly property int barContentWidth: Style.bar.iconFont
 
   // Panel is a bare Item with no size of its own, so the bar would hand this
   // widget zero width. Set it from the computed content width, never from a
@@ -538,7 +537,7 @@ Panel {
   function badgeColor() {
     if (blockedCount > 0) return root.urgent
     if (doneCount > 0) return root.finished
-    return root.accent
+    return root.working
   }
 
   function titleText() {
@@ -681,48 +680,58 @@ Panel {
     bar: root.bar
     opacity: root.reachable ? 1 : 0.5
     slotSize: root.barSlot
-    // The icon component is loaded into a square canvas of opticalSize, meant
-    // for one glyph. Widen it too, or the icon falls outside it and only the
-    // badge survives.
     opticalSize: root.barContentWidth
     tooltipText: root.plain(root.tooltipText())
 
     iconComponent: Component {
       Item {
-        Row {
+        Text {
+          id: serverIcon
           anchors.centerIn: parent
-          spacing: Style.space(5)
+          text: root.iconServer
+          textFormat: Text.PlainText
+          font.family: root.fontFamily
+          font.pixelSize: Style.bar.iconFont
+          renderType: Text.NativeRendering
+          color: root.opened ? root.accent : root.foreground
+        }
+
+        // The server count rides the glyph's top-right corner, the way an
+        // unread count rides an app icon: a bit over three quarters of the
+        // glyph's size and overlapping its corner, because a badge as big as
+        // the icon and sitting clear of it just reads as a second icon in the
+        // bar. Sized off the icon font so it follows a theme that resizes it.
+        Rectangle {
+          id: badge
+          anchors.horizontalCenter: serverIcon.horizontalCenter
+          anchors.horizontalCenterOffset: Math.round(Style.bar.iconFont * 0.44)
+          anchors.verticalCenter: serverIcon.verticalCenter
+          anchors.verticalCenterOffset: -Math.round(Style.bar.iconFont * 0.42)
+          visible: root.reachable && root.runningCount > 0 && root.badgeActive
+          height: Math.round(Style.bar.iconFont * 0.78)
+          width: Math.max(height, count.implicitWidth + Math.round(height * 0.45))
+          radius: height / 2
+          color: root.badgeColor()
+          // A rim in the bar's own background separates the badge from the
+          // glyph it sits on, so the corner it covers still reads as a corner
+          // and not as two shapes fused together.
+          border.width: Math.round(Style.bar.iconFont * 0.06)
+          border.color: Color.bar.background
 
           Text {
-            anchors.verticalCenter: parent.verticalCenter
-            text: root.iconServer
+            id: count
+            anchors.centerIn: parent
+            // Centring the text item leaves the digit riding high: a line box
+            // reserves descender room a digit never uses. Nudge it back down
+            // onto the middle of the disc.
+            anchors.verticalCenterOffset: Math.round(font.pixelSize * 0.1)
+            text: root.runningCount
             textFormat: Text.PlainText
             font.family: root.fontFamily
-            font.pixelSize: Style.bar.iconFont
+            font.pixelSize: Math.round((badge.height - 2 * badge.border.width) * 0.8)
+            font.bold: true
             renderType: Text.NativeRendering
-            color: root.opened ? root.accent : root.foreground
-          }
-
-          // The badge carries the alarm as well as the number: red when an
-          // agent somewhere is blocked on a question, so a herd that needs
-          // you says so without the panel being open.
-          Rectangle {
-            anchors.verticalCenter: parent.verticalCenter
-            visible: root.reachable && root.badgeCount > 0
-            height: Style.space(12)
-            width: root.badgeWidth
-            radius: height / 2
-            color: root.badgeColor()
-
-            Text {
-              anchors.centerIn: parent
-              text: root.badgeCount
-              textFormat: Text.PlainText
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
-              renderType: Text.NativeRendering
-              color: Color.background
-            }
+            color: Color.background
           }
         }
       }

--- a/Panel.qml
+++ b/Panel.qml
@@ -125,7 +125,9 @@ Panel {
   property int column: 0
   property int cursor: -1
 
-  readonly property int barContentWidth: Style.bar.iconFont
+  // The glyph, plus the few pixels the badge overhangs its corner by. Without
+  // them the disc spills onto whatever widget sits next in the bar.
+  readonly property int barContentWidth: Style.bar.iconFont + Style.space(4)
 
   // Panel is a bare Item with no size of its own, so the bar would hand this
   // widget zero width. Set it from the computed content width, never from a
@@ -701,18 +703,20 @@ Panel {
         }
 
         // The server count rides the glyph's top-right corner, the way an
-        // unread count rides an app icon: a bit over three quarters of the
-        // glyph's size and overlapping its corner, because a badge as big as
-        // the icon and sitting clear of it just reads as a second icon in the
-        // bar. Sized off the icon font so it follows a theme that resizes it.
+        // unread count rides an app icon, and is sized off the icon font so a
+        // theme that resizes the bar takes it along. The ratios are what the
+        // default 13px icon can carry: a 12px disc around a 9px digit. Three
+        // quarters of the glyph leaves the digit on 6px, which is a coloured
+        // speck rather than a count - unreadable at two digits - and the badge
+        // exists to say how many as much as it says which colour.
         Rectangle {
           id: badge
           anchors.horizontalCenter: serverIcon.horizontalCenter
-          anchors.horizontalCenterOffset: Math.round(Style.bar.iconFont * 0.44)
+          anchors.horizontalCenterOffset: Math.round(Style.bar.iconFont * 0.42)
           anchors.verticalCenter: serverIcon.verticalCenter
-          anchors.verticalCenterOffset: -Math.round(Style.bar.iconFont * 0.42)
+          anchors.verticalCenterOffset: -Math.round(Style.bar.iconFont * 0.40)
           visible: root.reachable && root.runningCount > 0 && root.badgeActive
-          height: Math.round(Style.bar.iconFont * 0.78)
+          height: Math.round(Style.bar.iconFont * 0.95)
           width: Math.max(height, count.implicitWidth + Math.round(height * 0.45))
           radius: height / 2
           color: root.badgeColor()
@@ -732,7 +736,7 @@ Panel {
             text: root.runningCount
             textFormat: Text.PlainText
             font.family: root.fontFamily
-            font.pixelSize: Math.round((badge.height - 2 * badge.border.width) * 0.8)
+            font.pixelSize: Math.round((badge.height - 2 * badge.border.width) * 0.88)
             font.bold: true
             renderType: Text.NativeRendering
             color: Color.background

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ list one click away.
 
 ## What it shows
 
-The bar carries the number of running servers. The badge turns red when an
-agent somewhere is blocked and waiting on an answer.
+The bar carries the number of running servers, on a badge sitting in the top
+right corner of the icon. It turns red when an agent is blocked and waiting on
+an answer, green when work finished while you were looking elsewhere, and amber
+while something is still running. When every agent is idle there is nothing to
+say, so the badge goes away and the icon stands on its own.
 
 Each row in the panel is one session:
 


### PR DESCRIPTION
The count moved onto the icon's corner. It was sitting beside the glyph, which
made the widget read as two icons rather than one.

Colours, most important first:

- **red** - an agent is blocked and waiting on you
- **green** - work finished that you haven't seen
- **yellow** - something is still working
- **nothing** - all idle, the badge hides

I also added the yellow for working. Feel free to discard the yellow if you'd
rather working stayed quiet - the priority above still works without it.

Also made the poll adapt, so a colour change shows in about a second instead of
up to twenty.
